### PR TITLE
Add required annotation to ChangingBlocksComponent

### DIFF
--- a/src/main/java/org/terasology/changingBlocks/ChangingBlocksComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/ChangingBlocksComponent.java
@@ -18,7 +18,9 @@ package org.terasology.changingBlocks;
 import java.util.Map;
 
 import org.terasology.entitySystem.Component;
+import org.terasology.world.block.ForceBlockActive;
 
+@ForceBlockActive
 public final class ChangingBlocksComponent implements Component {
 
     // determines if animation loops back to first block after last block is reached


### PR DESCRIPTION
Add a `@ForceBlockActive` annotation to the component so that when it is attached to a block the entity persists and the changing of this block works as expected.