### PR TITLE
Add conditional change system for block placement

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,9 +1,9 @@
 {
     "id" : "ChangingBlocks",
-    "version" : "0.1.1-SNAPSHOT",
-    "author" : "Cervator, mkienenb, Josharias",
+    "version" : "0.1.2-SNAPSHOT",
+    "author" : "Cervator, mkienenb, Josharias, Qwertygiy",
     "displayName" : "ChangingBlocks",
-    "description" : "Slow block animation.   Swaps a block with another block over longer periods of time",
+    "description" : "Allows blocks to become other blocks over time, or when their environment changes",
     "dependencies" : [],
     "isServerSideOnly" : false
 }

--- a/src/main/java/org/terasology/changingBlocks/conditional/BlockCondition.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/BlockCondition.java
@@ -19,14 +19,14 @@ import org.terasology.math.Side;
 
 public class BlockCondition {
     /**
-     * The chance that this condition will be executed if it is reached, where 0.0 = 0% and 1.0 = 100%
+     * The chance that the change will be executed if this condition is reached, where 0.0 = 0% and 1.0 = 100%
      */
     public float chance = 1.0F;
 
     /**
      * The block ID of the block which will replace this block.
      */
-    public String blockToBecome;
+    public String targetBlockID;
 
     /**
      * This base condition should be used if another block is part of the condition.
@@ -35,7 +35,7 @@ public class BlockCondition {
         /**
          * The block ID of the block which will trigger this action
          */
-        public String triggerBlock;
+        public String triggerBlockID;
     }
 
     /**

--- a/src/main/java/org/terasology/changingBlocks/conditional/BlockCondition.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/BlockCondition.java
@@ -54,6 +54,8 @@ public class BlockCondition {
          * If true, ignore distances and only check if it touches this block.
          */
         public boolean adjacent = false;
+
+        public boolean throughWalls = false;
     }
 
     /**
@@ -76,6 +78,8 @@ public class BlockCondition {
          * The field of view to check. 0 = direct line from faces only; 1 = any block on that side of this block.
          */
         public float fieldOfView = 0;
+
+        public boolean throughWalls = false;
     }
 
     /**
@@ -100,6 +104,8 @@ public class BlockCondition {
          * The maximum distance away the triggering entity must be located. Default 1.5F.
          */
         public float maxDistance = 1.5F;
+
+        public boolean throughWalls = false;
     }
 
     /**
@@ -122,5 +128,7 @@ public class BlockCondition {
          * The field of view to check. 0 = direct line from faces only; 1 = any block on that side of this block.
          */
         public float fieldOfView = 0;
+
+        public boolean throughWalls = false;
     }
 }

--- a/src/main/java/org/terasology/changingBlocks/conditional/BlockCondition.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/BlockCondition.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.changingBlocks.conditional;
+
+import org.terasology.math.Side;
+
+public class BlockCondition {
+    /**
+     * The chance that this condition will be executed if it is reached, where 0.0 = 0% and 1.0 = 100%
+     */
+    public float chance = 1.0F;
+
+    /**
+     * The block ID of the block which will replace this block.
+     */
+    public String blockToBecome;
+
+    /**
+     * This base condition should be used if another block is part of the condition.
+     */
+    public static class BlockTrigger extends BlockCondition {
+        /**
+         * The block ID of the block which will trigger this action
+         */
+        public String triggerBlock;
+    }
+
+    /**
+     * This condition should be used if the presence of a nearby or adjacent block should trigger the condition.
+     */
+    public static class BlockNearby extends BlockTrigger {
+        /**
+         * The minimum distance away the triggering block must be located. Default 0.
+         */
+        public float minDistance = 0;
+        /**
+         * The maximum distance away the triggering block must be located. Default 1.5F.
+         */
+        public float maxDistance = 1.5F;
+        /**
+         * If true, ignore distances and only check if it touches this block.
+         */
+        public boolean adjacent = false;
+    }
+
+    /**
+     * This condition should be used if the presence of a nearby or adjacent block in a specific direction should trigger the condition.
+     */
+    public static class BlockDirected extends BlockTrigger {
+        /**
+         * Which side of this block must be facing the trigger
+         */
+        public Side blockSide;
+        /**
+         * The minimum distance away the triggering block must be located. Default 0.
+         */
+        public float minDistance = 0;
+        /**
+         * The maximum distance away the triggering block must be located. Default 1.
+         */
+        public float maxDistance = 1F;
+        /**
+         * The field of view to check. 0 = direct line from faces only; 1 = any block on that side of this block.
+         */
+        public float fieldOfView = 0;
+    }
+
+    /**
+     * This base condition should be used if an entity is part of the condition.
+     */
+    public static class EntityTrigger extends BlockCondition {
+        /**
+         * The ID of the entity which will trigger this action
+         */
+        public String triggerEntity;
+    }
+
+    /**
+     * This condition should be used if the presence of a nearby entity triggers the condition.
+     */
+    public static class EntityNearby extends EntityTrigger {
+        /**
+         * The minimum distance away the triggering entity must be located. Default 0.
+         */
+        public float minDistance = 0;
+        /**
+         * The maximum distance away the triggering entity must be located. Default 1.5F.
+         */
+        public float maxDistance = 1.5F;
+    }
+
+    /**
+     * This condition should be used if the presence of a nearby entity in a certain direction triggers the condition.
+     */
+    public static class EntityDirected extends EntityTrigger {
+        /**
+         * Which side of this block must be facing the trigger
+         */
+        public Side blockSide;
+        /**
+         * The minimum distance away the triggering entity must be located. Default 0.
+         */
+        public float minDistance = 0;
+        /**
+         * The maximum distance away the triggering entity must be located. Default 1.
+         */
+        public float maxDistance = 1F;
+        /**
+         * The field of view to check. 0 = direct line from faces only; 1 = any block on that side of this block.
+         */
+        public float fieldOfView = 0;
+    }
+}

--- a/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
@@ -347,10 +347,12 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      */
     @ReceiveEvent(components = {ConditionalBlockChangeComponent.class, LocationComponent.class, BlockComponent.class})
     public void onRemoving(BeforeRemoveComponent event, EntityRef entity) {
-        for (List<EntityRef> refs : triggerCollections.values())
-        {
-            refs.remove(entity);
-        }
+        triggerCollections.replaceAll(
+                (trigger, refs) -> {
+                    refs.remove(entity);
+                    return refs;
+                }
+        );
     }
 
     /**

--- a/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
@@ -91,8 +91,14 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      */
     public void registerTrigger(String trigger, EntityRef triggerable, Boolean isBlock)
     {
-        List<EntityRef> triggerTaggers = triggerCollections.computeIfAbsent(trigger, k -> new ArrayList<>());
-        triggerTaggers.add(triggerable);
+        triggerCollections.compute(
+                trigger,
+                (k, v) -> {
+                    if (v == null) v = new ArrayList<>();
+                    v.add(triggerable);
+                    return v;
+                }
+        );
     }
 
     /**

--- a/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
@@ -87,12 +87,13 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      * @param triggerable The entity that may be changed by the trigger.
      * @param isBlock Whether this trigger is a block or a free-moving entity like a player or NPC.
      */
-    public void registerTrigger(String trigger, EntityRef triggerable, Boolean isBlock)
-    {
+    public void registerTrigger(String trigger, EntityRef triggerable, Boolean isBlock) {
         triggerCollections.compute(
                 trigger,
                 (k, v) -> {
-                    if (v == null) v = new ArrayList<>();
+                    if (v == null) {
+                        v = new ArrayList<>();
+                    }
                     v.add(triggerable);
                     return v;
                 }
@@ -107,8 +108,7 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      * @param triggerName The string representing this entity's type.
      * @param isBlock Whether this entity is a block entity or another type.
      */
-    public void checkLocational(EntityRef entity, Vector3f triggerPosition, String triggerName, Boolean isBlock)
-    {
+    public void checkLocational(EntityRef entity, Vector3f triggerPosition, String triggerName, Boolean isBlock) {
         for (EntityRef blockChange : triggerCollections.get(triggerName)) {
             if (isBlock) {
                 ChangeBlockBlockNearbyComponent bn = blockChange.getComponent(ChangeBlockBlockNearbyComponent.class);
@@ -235,8 +235,7 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      * @param entity The item.
      */
     @ReceiveEvent(components =  {LocationComponent.class, ItemComponent.class})
-    public void onItemUpdate(LocationChangedEvent event, EntityRef entity)
-    {
+    public void onItemUpdate(LocationChangedEvent event, EntityRef entity) {
         String trigger = "item";
         if (triggerCollections.containsKey(trigger)) {
             LocationComponent lc = entity.getComponent(LocationComponent.class);
@@ -250,8 +249,7 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      * @param entity The NPC.
      */
     @ReceiveEvent(components = {LocationComponent.class, CharacterComponent.class})
-    public void onCharacterUpdate(LocationChangedEvent event, EntityRef entity)
-    {
+    public void onCharacterUpdate(LocationChangedEvent event, EntityRef entity) {
         String trigger = "npc";
         if (triggerCollections.containsKey(trigger)) {
             LocationComponent lc = entity.getComponent(LocationComponent.class);
@@ -265,8 +263,7 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      * @param entity The player.
      */
     @ReceiveEvent(components = {LocationComponent.class, PlayerCharacterComponent.class})
-    public void onPlayerUpdate(LocationChangedEvent event, EntityRef entity)
-    {
+    public void onPlayerUpdate(LocationChangedEvent event, EntityRef entity) {
         String trigger = "player";
         if (triggerCollections.containsKey(trigger)) {
             LocationComponent lc = entity.getComponent(LocationComponent.class);
@@ -363,8 +360,7 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      */
     @Override
     public void shutdown() {
-        for (String trigger : triggerCollections.keySet())
-        {
+        for (String trigger : triggerCollections.keySet()) {
             log.info("Clearing list of " + triggerCollections.get(trigger).size() + " entities triggered by " + trigger);
         }
         triggerCollections.clear();

--- a/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
@@ -89,7 +89,7 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      */
     public void registerTrigger(String trigger, EntityRef triggerable, Boolean isBlock) {
         triggerCollections.compute(
-                trigger,
+                trigger.toLowerCase(),
                 (k, v) -> {
                     if (v == null) {
                         v = new ArrayList<>();
@@ -292,7 +292,7 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
      */
     @ReceiveEvent(components = {BlockComponent.class, LocationComponent.class})
     public void onUpdate(OnChangedBlock event, EntityRef entity) {
-        String trigger = event.getNewType().getURI().toString();
+        String trigger = event.getNewType().getURI().toString().toLowerCase();
         if (triggerCollections.containsKey(trigger)) {
             checkLocational(entity, event.getBlockPosition().toVector3f(), trigger, true);
         }

--- a/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.changingBlocks.conditional;
+
+import org.terasology.changingBlocks.ChangingBlocksComponent;
+import org.terasology.changingBlocks.OnBlockSequenceComplete;
+import org.terasology.engine.Time;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.registry.In;
+import org.terasology.world.WorldProvider;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockComponent;
+import org.terasology.world.block.BlockManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class ConditionalBlocksSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+    private static final int CHECK_INTERVAL = 1000;
+
+    @In
+    private BlockManager blockManager;
+    @In
+    private EntityManager entityManager;
+    @In
+    private Time timer;
+    @In
+    private WorldProvider worldprovider;
+
+    private long lastCheckTime;
+
+    @Override
+    public void initialise() {
+    }
+
+    @ReceiveEvent(components = {ChangingBlocksComponent.class, LocationComponent.class, BlockComponent.class})
+    public void onSpawn(OnAddedComponent event, EntityRef entity) {
+        long initTime = timer.getGameTimeInMs();
+        ChangingBlocksComponent changingBlocks = entity.getComponent(ChangingBlocksComponent.class);
+        LocationComponent locComponent = entity.getComponent(LocationComponent.class);
+        Block currentBlock = worldprovider.getBlock(locComponent.getWorldPosition());
+        String currentBlockFamilyStage = currentBlock.getURI().toString();
+        changingBlocks.timeInGameMsToNextStage = changingBlocks.blockFamilyStages.get(currentBlockFamilyStage);
+        changingBlocks.lastGameTimeCheck = initTime;
+        entity.saveComponent(changingBlocks);
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public void update(float delta) {
+        // System last time check is to try to improve performance
+        long gameTimeInMs = timer.getGameTimeInMs();
+        if (lastCheckTime + CHECK_INTERVAL < gameTimeInMs) {
+            for (EntityRef changingBlocks : entityManager.getEntitiesWith(ChangingBlocksComponent.class, BlockComponent.class, LocationComponent.class)) {
+                ChangingBlocksComponent blockAnimation = changingBlocks.getComponent(ChangingBlocksComponent.class);
+                if (blockAnimation.stopped) {
+                    return;
+                }
+                if (blockAnimation.lastGameTimeCheck == -1) {
+                    blockAnimation.lastGameTimeCheck = gameTimeInMs;
+                    changingBlocks.saveComponent(blockAnimation);
+                    return;
+                }
+                if (gameTimeInMs - blockAnimation.lastGameTimeCheck > blockAnimation.timeInGameMsToNextStage) {
+                    blockAnimation.lastGameTimeCheck = timer.getGameTimeInMs();
+                    LocationComponent locComponent = changingBlocks.getComponent(LocationComponent.class);
+                    Block currentBlock = worldprovider.getBlock(locComponent.getWorldPosition());
+                    String currentBlockFamilyStage = currentBlock.getURI().toString();
+                    Set<String> keySet = blockAnimation.blockFamilyStages.keySet();
+                    List<String> keyList = new ArrayList<>(keySet);
+                    int currentstageIndex = keyList.indexOf(currentBlockFamilyStage);
+                    int lastStageIndex = blockAnimation.blockFamilyStages.size() - 1;
+                    if (lastStageIndex > currentstageIndex) {
+                        currentstageIndex++;
+                        if (currentstageIndex == lastStageIndex) {
+                            if (blockAnimation.loops) {
+                                currentstageIndex = 0;
+                            } else {
+                                blockAnimation.stopped = true;
+                                changingBlocks.send(new OnBlockSequenceComplete());
+                            }
+                        }
+                        String newBlockUri = keyList.get(currentstageIndex);
+                        Block newBlock = blockManager.getBlock(newBlockUri);
+                        if (newBlockUri.equals(newBlock.getURI().toString())) {
+                            worldprovider.setBlock(new Vector3i(locComponent.getWorldPosition()), newBlock);
+                            blockAnimation.timeInGameMsToNextStage = blockAnimation.blockFamilyStages.get(currentBlockFamilyStage);
+                        }
+                    }
+                    changingBlocks.saveComponent(blockAnimation);
+                }
+            }
+            lastCheckTime = gameTimeInMs;
+        }
+    }
+}

--- a/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
@@ -17,6 +17,10 @@ package org.terasology.changingBlocks.conditional;
 
 import org.terasology.changingBlocks.ChangingBlocksComponent;
 import org.terasology.changingBlocks.OnBlockSequenceComplete;
+import org.terasology.changingBlocks.conditional.components.ChangeBlockBlockDirectedComponent;
+import org.terasology.changingBlocks.conditional.components.ChangeBlockBlockNearbyComponent;
+import org.terasology.changingBlocks.conditional.components.ChangeBlockEntityDirectedComponent;
+import org.terasology.changingBlocks.conditional.components.ChangeBlockEntityNearbyComponent;
 import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -27,8 +31,16 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.Direction;
+import org.terasology.math.Side;
+import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.physics.Physics;
+import org.terasology.physics.StandardCollisionGroup;
+import org.terasology.physics.bullet.BulletPhysics;
 import org.terasology.registry.In;
+import org.terasology.utilities.random.Random;
+import org.terasology.world.OnChangedBlock;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockComponent;
@@ -40,33 +52,140 @@ import java.util.Set;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class ConditionalBlocksSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
-    private static final int CHECK_INTERVAL = 1000;
 
     @In
     private BlockManager blockManager;
     @In
     private EntityManager entityManager;
     @In
-    private Time timer;
-    @In
     private WorldProvider worldprovider;
+    @In
+    private Physics physics;
+    @In
+    private Random random;
 
-    private long lastCheckTime;
+    private List<String> blockTriggers = new ArrayList<>();
+    private List<String> entityTriggers = new ArrayList<>();
 
     @Override
     public void initialise() {
     }
 
-    @ReceiveEvent(components = {ChangingBlocksComponent.class, LocationComponent.class, BlockComponent.class})
-    public void onSpawn(OnAddedComponent event, EntityRef entity) {
-        long initTime = timer.getGameTimeInMs();
-        ChangingBlocksComponent changingBlocks = entity.getComponent(ChangingBlocksComponent.class);
-        LocationComponent locComponent = entity.getComponent(LocationComponent.class);
-        Block currentBlock = worldprovider.getBlock(locComponent.getWorldPosition());
-        String currentBlockFamilyStage = currentBlock.getURI().toString();
-        changingBlocks.timeInGameMsToNextStage = changingBlocks.blockFamilyStages.get(currentBlockFamilyStage);
-        changingBlocks.lastGameTimeCheck = initTime;
-        entity.saveComponent(changingBlocks);
+    @ReceiveEvent(components = {LocationComponent.class, BlockComponent.class})
+    public void onUpdate(OnChangedBlock event, EntityRef entity) {
+        //if this block is a registered trigger
+        if (blockTriggers.contains(event.getNewType().getURI().toString())) {
+            //get every non-directional changer
+            for (EntityRef blockChange : entityManager.getEntitiesWith(ChangeBlockBlockNearbyComponent.class)) {
+                ChangeBlockBlockNearbyComponent bn = blockChange.getComponent(ChangeBlockBlockNearbyComponent.class);
+                //check the possible changes for this block
+                for (BlockCondition.BlockNearby change : bn.changes) {
+                    //if the trigger matches
+                    if (change.triggerBlock.equals(event.getNewType().getURI().toString())) {
+                        LocationComponent blockLocation = blockChange.getComponent(LocationComponent.class);
+                        Vector3f changeSpot = blockLocation.getWorldPosition();
+                        float distance = changeSpot.distance(event.getBlockPosition().toVector3f());
+                        //if it is adjacent
+                        if (change.adjacent && distance <= 1)
+                        {
+                            worldprovider.setBlock(new Vector3i(changeSpot.x, changeSpot.y, changeSpot.z), blockManager.getBlock(change.blockToBecome));
+                        } else {
+                            //if it is within range
+                            if (distance >= change.minDistance && distance <= change.maxDistance) {
+                                Vector3f direction = event.getBlockPosition().toVector3f().sub(changeSpot);
+                                //if the change can occur when obstructed, or otherwise if there is no obstruction
+                                if (change.throughWalls || physics.rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD).getEntity() == entity) {
+                                    //if the random odds are in our favor
+                                    if (change.chance >= random.nextFloat()) {
+                                        worldprovider.setBlock(new Vector3i(changeSpot.x, changeSpot.y, changeSpot.z), blockManager.getBlock(change.blockToBecome));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            //get every directional changer
+            for (EntityRef blockChange : entityManager.getEntitiesWith(ChangeBlockBlockDirectedComponent.class)) {
+                ChangeBlockBlockDirectedComponent bd = blockChange.getComponent(ChangeBlockBlockDirectedComponent.class);
+                //check the possible changes for this block
+                for (BlockCondition.BlockDirected change : bd.changes) {
+                    //if the trigger matches
+                    if (change.triggerBlock.equals(event.getNewType().getURI().toString())) {
+                        LocationComponent blockLocation = blockChange.getComponent(LocationComponent.class);
+                        Vector3f changeSpot = blockLocation.getWorldPosition();
+                        float distance = changeSpot.distance(event.getBlockPosition().toVector3f());
+                        //if it is within range
+                        if (distance >= change.minDistance && distance <= change.maxDistance) {
+                            Side global = change.blockSide.getRelativeSide(Direction.inDirection(blockLocation.getLocalDirection()));
+                            Vector3f direction = event.getBlockPosition().toVector3f().sub(changeSpot);
+                            //if it's on the correct side of the block
+                            if (Side.inDirection(direction) == global) {
+                                //if the angle is within the change's field of view limit
+                                if (direction.angle(global.getVector3i().toVector3f()) <= change.fieldOfView) {
+                                    //if the change can occur when obstructed, or otherwise if there is no obstruction
+                                    if (change.throughWalls || physics.rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD).getEntity() == entity) {
+                                        //if the random odds are in our favor
+                                        if (change.chance >= random.nextFloat()) {
+                                            worldprovider.setBlock(new Vector3i(changeSpot.x, changeSpot.y, changeSpot.z), blockManager.getBlock(change.blockToBecome));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ReceiveEvent(components = {ChangeBlockBlockDirectedComponent.class, LocationComponent.class, BlockComponent.class})
+    public void onSpawnBlockDirected(OnAddedComponent event, EntityRef entity) {
+        ChangeBlockBlockDirectedComponent changingBlocks = entity.getComponent(ChangeBlockBlockDirectedComponent.class);
+        List<BlockCondition.BlockDirected> listOfChanges = changingBlocks.changes;
+        for (BlockCondition.BlockDirected bc : listOfChanges) {
+            String trigger = bc.triggerBlock;
+            if (!blockTriggers.contains(trigger)) {
+                blockTriggers.add(trigger);
+            }
+        }
+    }
+
+    @ReceiveEvent(components = {ChangeBlockBlockNearbyComponent.class, LocationComponent.class, BlockComponent.class})
+    public void onSpawnBlockNearby(OnAddedComponent event, EntityRef entity) {
+        ChangeBlockBlockNearbyComponent changingBlocks = entity.getComponent(ChangeBlockBlockNearbyComponent.class);
+        List<BlockCondition.BlockNearby> listOfChanges = changingBlocks.changes;
+        for (BlockCondition.BlockNearby bc : listOfChanges) {
+            String trigger = bc.triggerBlock;
+            if (!blockTriggers.contains(trigger)) {
+                blockTriggers.add(trigger);
+            }
+        }
+    }
+
+    @ReceiveEvent(components = {ChangeBlockEntityDirectedComponent.class, LocationComponent.class, BlockComponent.class})
+    public void onSpawnEntityDirected(OnAddedComponent event, EntityRef entity) {
+        ChangeBlockEntityDirectedComponent changingBlocks = entity.getComponent(ChangeBlockEntityDirectedComponent.class);
+        List<BlockCondition.EntityDirected> listOfChanges = changingBlocks.changes;
+        for (BlockCondition.EntityDirected ec : listOfChanges) {
+            String trigger = ec.triggerEntity;
+            if (!entityTriggers.contains(trigger)) {
+                entityTriggers.add(trigger);
+            }
+        }
+    }
+
+    @ReceiveEvent(components = {ChangeBlockEntityNearbyComponent.class, LocationComponent.class, BlockComponent.class})
+    public void onSpawnEntityNearby(OnAddedComponent event, EntityRef entity) {
+        ChangeBlockEntityNearbyComponent changingBlocks = entity.getComponent(ChangeBlockEntityNearbyComponent.class);
+        List<BlockCondition.EntityNearby> listOfChanges = changingBlocks.changes;
+        for (BlockCondition.EntityNearby ec : listOfChanges) {
+            String trigger = ec.triggerEntity;
+            if (!entityTriggers.contains(trigger)) {
+                entityTriggers.add(trigger);
+            }
+        }
     }
 
     @Override
@@ -76,49 +195,6 @@ public class ConditionalBlocksSystem extends BaseComponentSystem implements Upda
 
     @Override
     public void update(float delta) {
-        // System last time check is to try to improve performance
-        long gameTimeInMs = timer.getGameTimeInMs();
-        if (lastCheckTime + CHECK_INTERVAL < gameTimeInMs) {
-            for (EntityRef changingBlocks : entityManager.getEntitiesWith(ChangingBlocksComponent.class, BlockComponent.class, LocationComponent.class)) {
-                ChangingBlocksComponent blockAnimation = changingBlocks.getComponent(ChangingBlocksComponent.class);
-                if (blockAnimation.stopped) {
-                    return;
-                }
-                if (blockAnimation.lastGameTimeCheck == -1) {
-                    blockAnimation.lastGameTimeCheck = gameTimeInMs;
-                    changingBlocks.saveComponent(blockAnimation);
-                    return;
-                }
-                if (gameTimeInMs - blockAnimation.lastGameTimeCheck > blockAnimation.timeInGameMsToNextStage) {
-                    blockAnimation.lastGameTimeCheck = timer.getGameTimeInMs();
-                    LocationComponent locComponent = changingBlocks.getComponent(LocationComponent.class);
-                    Block currentBlock = worldprovider.getBlock(locComponent.getWorldPosition());
-                    String currentBlockFamilyStage = currentBlock.getURI().toString();
-                    Set<String> keySet = blockAnimation.blockFamilyStages.keySet();
-                    List<String> keyList = new ArrayList<>(keySet);
-                    int currentstageIndex = keyList.indexOf(currentBlockFamilyStage);
-                    int lastStageIndex = blockAnimation.blockFamilyStages.size() - 1;
-                    if (lastStageIndex > currentstageIndex) {
-                        currentstageIndex++;
-                        if (currentstageIndex == lastStageIndex) {
-                            if (blockAnimation.loops) {
-                                currentstageIndex = 0;
-                            } else {
-                                blockAnimation.stopped = true;
-                                changingBlocks.send(new OnBlockSequenceComplete());
-                            }
-                        }
-                        String newBlockUri = keyList.get(currentstageIndex);
-                        Block newBlock = blockManager.getBlock(newBlockUri);
-                        if (newBlockUri.equals(newBlock.getURI().toString())) {
-                            worldprovider.setBlock(new Vector3i(locComponent.getWorldPosition()), newBlock);
-                            blockAnimation.timeInGameMsToNextStage = blockAnimation.blockFamilyStages.get(currentBlockFamilyStage);
-                        }
-                    }
-                    changingBlocks.saveComponent(blockAnimation);
-                }
-            }
-            lastCheckTime = gameTimeInMs;
-        }
+
     }
 }

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockBlockDirectedComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockBlockDirectedComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.changingBlocks.conditional.components;
+
+import org.terasology.changingBlocks.conditional.BlockCondition;
+
+import java.util.List;
+
+public class ChangeBlockBlockDirectedComponent implements ConditionalBlockChangeComponent {
+    public List<BlockCondition.BlockDirected> changes;
+}

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockBlockNearbyComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockBlockNearbyComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.changingBlocks.conditional.components;
+
+import org.terasology.changingBlocks.conditional.BlockCondition;
+
+import java.util.List;
+
+public class ChangeBlockBlockNearbyComponent implements ConditionalBlockChangeComponent {
+    public List<BlockCondition.BlockNearby> changes;
+}

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockEntityDirectedComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockEntityDirectedComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.changingBlocks.conditional.components;
+
+import org.terasology.changingBlocks.conditional.BlockCondition;
+
+import java.util.List;
+
+public class ChangeBlockEntityDirectedComponent implements ConditionalBlockChangeComponent {
+    public List<BlockCondition.EntityDirected> changes;
+}

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockEntityNearbyComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockEntityNearbyComponent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.changingBlocks.conditional.components;
+
+import org.terasology.changingBlocks.conditional.BlockCondition;
+
+import java.util.List;
+
+public class ChangeBlockEntityNearbyComponent implements ConditionalBlockChangeComponent {
+    public List<BlockCondition.EntityNearby> changes;
+}

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ConditionalBlockChangeComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ConditionalBlockChangeComponent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.changingBlocks.conditional.components;
+
+import org.terasology.entitySystem.Component;
+
+public interface ConditionalBlockChangeComponent extends Component {
+}


### PR DESCRIPTION
This PR adds a simple system for creating and handling blocks that should be changed to another block when in the presence of another block or entity. The "Nearby" components merely check for the presence within a certain distance, whereas the "Directed" components additionally require the triggering object to be located in a certain direction relative to the changing block.

The original intended use case of this system is to allow Dirt blocks to be converted into Mud blocks when adjacent to a Water block.

Completed:
- [x] Components - BlockNearby, BlockDirected, EntityNearby, EntityDirected
- [x] Systems - BlockNearby, BlockDirected
- [x] Systems - EntityNearby, EntityDirected

ToDo:
- [ ] Allow the blocks to change when they are placed into an environment where a triggering object already exists
- [ ] Measure performance impact of current system, which scans a list of all loaded entities that may be triggered by the block being placed, vs. a system that uses entities to store the regions in which each triggerable entity could be activated

The following engine PRs are required for this to work properly:
- ✔️ https://github.com/MovingBlocks/Terasology/pull/3783 (for block placement triggers)
- ✔️ https://github.com/MovingBlocks/Terasology/pull/3786 (for entity triggers)