### PR TITLE
fix: make ChangingBlocks case insensitive via BlockUri

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ When the last block is reached, either loop back to the first one, or send an On
 
 Example component to add to a prefab:
 
-	"ChangingBlocks" : {
-		"blockFamilyStages" : [
-		  { "key": "Crops:Corn1", "value": 30000 },
-			{ "key": "Crops:Corn2", "value": 30000 },
-			{ "key": "Crops:Corn3", "value": 30000 },
-			{ "key": "Crops:Corn4", "value": 30000 },
-			{ "key": "Crops:Corn5", "value": 30000 },
-			{ "key": "Crops:Corn6", "value": 30000 },
-			{ "key": "Crops:Corn7", "value": 30000 }
-    ],
-		"loops" : false
-	}
+    "ChangingBlocks" : {
+        "blockFamilyStages" : [
+            { "key": "Crops:Corn1", "value": 30000 },
+            { "key": "Crops:Corn2", "value": 30000 },
+            { "key": "Crops:Corn3", "value": 30000 },
+            { "key": "Crops:Corn4", "value": 30000 },
+            { "key": "Crops:Corn5", "value": 30000 },
+            { "key": "Crops:Corn6", "value": 30000 },
+            { "key": "Crops:Corn7", "value": 30000 }
+        ],
+        "loops" : false
+    }
 
 Example prefab to add to each block:
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ When the last block is reached, either loop back to the first one, or send an On
 Example component to add to a prefab:
 
 	"ChangingBlocks" : {
-		"blockFamilyStages" : {  
-		             "Crops:Corn1" : 30000,
-								 "Crops:Corn2" : 30000,
-								 "Crops:Corn3" : 30000,
-								 "Crops:Corn4" : 30000,
-								 "Crops:Corn5" : 30000,
-								 "Crops:Corn6" : 30000,
-								 "Crops:Corn7" : 30000 },
+		"blockFamilyStages" : [
+		  { "key": "Crops:Corn1", "value": 30000 },
+			{ "key": "Crops:Corn2", "value": 30000 },
+			{ "key": "Crops:Corn3", "value": 30000 },
+			{ "key": "Crops:Corn4", "value": 30000 },
+			{ "key": "Crops:Corn5", "value": 30000 },
+			{ "key": "Crops:Corn6", "value": 30000 },
+			{ "key": "Crops:Corn7", "value": 30000 }
+    ],
 		"loops" : false
 	}
 

--- a/src/main/java/org/terasology/changingBlocks/ChangingBlocksComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/ChangingBlocksComponent.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks;
 
+import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.world.block.ForceBlockActive;
 import org.terasology.gestalt.entitysystem.component.Component;
 
@@ -17,7 +18,7 @@ public final class ChangingBlocksComponent implements Component<ChangingBlocksCo
     public boolean stopped;
 
     // List of block names to cycle through
-    public Map<String, Long> blockFamilyStages;
+    public Map<SimpleUri, Long> blockFamilyStages;
 
     // internal: used to determine time to next block change
     public long timeInGameMsToNextStage;

--- a/src/main/java/org/terasology/changingBlocks/ChangingBlocksComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/ChangingBlocksComponent.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks;
 
@@ -31,7 +31,7 @@ public final class ChangingBlocksComponent implements Component<ChangingBlocksCo
         this.loops = other.loops;
         this.stopped = other.stopped;
         this.blockFamilyStages.clear();
-        other.blockFamilyStages.forEach((k,v) -> this.blockFamilyStages.put(k,v));
+        other.blockFamilyStages.forEach((k, v) -> this.blockFamilyStages.put(k, v));
         this.timeInGameMsToNextStage = other.timeInGameMsToNextStage;
         this.lastGameTimeCheck = other.lastGameTimeCheck;
     }

--- a/src/main/java/org/terasology/changingBlocks/ChangingBlocksComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/ChangingBlocksComponent.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks;
 
-import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.world.block.BlockUri;
 import org.terasology.engine.world.block.ForceBlockActive;
 import org.terasology.gestalt.entitysystem.component.Component;
 
@@ -18,7 +18,7 @@ public final class ChangingBlocksComponent implements Component<ChangingBlocksCo
     public boolean stopped;
 
     // List of block names to cycle through
-    public Map<SimpleUri, Long> blockFamilyStages;
+    public Map<BlockUri, Long> blockFamilyStages;
 
     // internal: used to determine time to next block change
     public long timeInGameMsToNextStage;

--- a/src/main/java/org/terasology/changingBlocks/ChangingBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/ChangingBlocksSystem.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2015 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks;
 
 import org.joml.RoundingMode;
@@ -80,7 +67,8 @@ public class ChangingBlocksSystem extends BaseComponentSystem implements UpdateS
         // System last time check is to try to improve performance
         long gameTimeInMs = timer.getGameTimeInMs();
         if (lastCheckTime + CHECK_INTERVAL < gameTimeInMs) {
-            for (EntityRef changingBlocks : entityManager.getEntitiesWith(ChangingBlocksComponent.class, BlockComponent.class, LocationComponent.class)) {
+            for (EntityRef changingBlocks : entityManager.getEntitiesWith(ChangingBlocksComponent.class,
+                    BlockComponent.class, LocationComponent.class)) {
                 ChangingBlocksComponent blockAnimation = changingBlocks.getComponent(ChangingBlocksComponent.class);
                 if (blockAnimation.stopped) {
                     return;

--- a/src/main/java/org/terasology/changingBlocks/ChangingBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/ChangingBlocksSystem.java
@@ -18,6 +18,7 @@ package org.terasology.changingBlocks;
 import org.joml.RoundingMode;
 import org.joml.Vector3f;
 import org.joml.Vector3i;
+import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
@@ -63,7 +64,7 @@ public class ChangingBlocksSystem extends BaseComponentSystem implements UpdateS
         ChangingBlocksComponent changingBlocks = entity.getComponent(ChangingBlocksComponent.class);
         LocationComponent locComponent = entity.getComponent(LocationComponent.class);
         Block currentBlock = worldprovider.getBlock(locComponent.getWorldPosition(new Vector3f()));
-        String currentBlockFamilyStage = currentBlock.getURI().toString();
+        SimpleUri currentBlockFamilyStage = new SimpleUri(currentBlock.getURI().getModuleName(), currentBlock.getURI().getIdentifier());
         changingBlocks.timeInGameMsToNextStage = changingBlocks.blockFamilyStages.get(currentBlockFamilyStage);
         changingBlocks.lastGameTimeCheck = initTime;
         entity.saveComponent(changingBlocks);
@@ -94,8 +95,8 @@ public class ChangingBlocksSystem extends BaseComponentSystem implements UpdateS
                     LocationComponent locComponent = changingBlocks.getComponent(LocationComponent.class);
                     Block currentBlock = worldprovider.getBlock(locComponent.getWorldPosition(new Vector3f()));
                     String currentBlockFamilyStage = currentBlock.getURI().toString();
-                    Set<String> keySet = blockAnimation.blockFamilyStages.keySet();
-                    List<String> keyList = new ArrayList<>(keySet);
+                    Set<SimpleUri> keySet = blockAnimation.blockFamilyStages.keySet();
+                    List<SimpleUri> keyList = new ArrayList<>(keySet);
                     int currentstageIndex = keyList.indexOf(currentBlockFamilyStage);
                     int lastStageIndex = blockAnimation.blockFamilyStages.size() - 1;
                     if (lastStageIndex > currentstageIndex) {
@@ -108,8 +109,8 @@ public class ChangingBlocksSystem extends BaseComponentSystem implements UpdateS
                                 changingBlocks.send(new OnBlockSequenceComplete());
                             }
                         }
-                        String newBlockUri = keyList.get(currentstageIndex);
-                        Block newBlock = blockManager.getBlock(newBlockUri);
+                        SimpleUri newBlockUri = keyList.get(currentstageIndex);
+                        Block newBlock = blockManager.getBlock(newBlockUri.toString());
                         if (newBlockUri.equals(newBlock.getURI().toString())) {
                             worldprovider.setBlock(new Vector3i(locComponent.getWorldPosition(new Vector3f()), RoundingMode.FLOOR), newBlock);
                             blockAnimation.timeInGameMsToNextStage = blockAnimation.blockFamilyStages.get(currentBlockFamilyStage);

--- a/src/main/java/org/terasology/changingBlocks/ChangingBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/ChangingBlocksSystem.java
@@ -82,7 +82,8 @@ public class ChangingBlocksSystem extends BaseComponentSystem implements UpdateS
                     blockAnimation.lastGameTimeCheck = timer.getGameTimeInMs();
                     LocationComponent locComponent = changingBlocks.getComponent(LocationComponent.class);
                     Block currentBlock = worldprovider.getBlock(locComponent.getWorldPosition(new Vector3f()));
-                    String currentBlockFamilyStage = currentBlock.getURI().toString();
+                    SimpleUri currentBlockFamilyStage = new SimpleUri(currentBlock.getURI().getModuleName(),
+                            currentBlock.getURI().getIdentifier());
                     Set<SimpleUri> keySet = blockAnimation.blockFamilyStages.keySet();
                     List<SimpleUri> keyList = new ArrayList<>(keySet);
                     int currentstageIndex = keyList.indexOf(currentBlockFamilyStage);
@@ -99,7 +100,7 @@ public class ChangingBlocksSystem extends BaseComponentSystem implements UpdateS
                         }
                         SimpleUri newBlockUri = keyList.get(currentstageIndex);
                         Block newBlock = blockManager.getBlock(newBlockUri.toString());
-                        if (newBlockUri.equals(newBlock.getURI().toString())) {
+                        if (newBlockUri.equals(new SimpleUri(newBlock.getURI().getModuleName(), newBlock.getURI().getIdentifier()))) {
                             worldprovider.setBlock(new Vector3i(locComponent.getWorldPosition(new Vector3f()), RoundingMode.FLOOR), newBlock);
                             blockAnimation.timeInGameMsToNextStage = blockAnimation.blockFamilyStages.get(currentBlockFamilyStage);
                         }

--- a/src/main/java/org/terasology/changingBlocks/OnBlockSequenceComplete.java
+++ b/src/main/java/org/terasology/changingBlocks/OnBlockSequenceComplete.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks;
 
 import org.terasology.engine.entitySystem.event.AbstractConsumableEvent;

--- a/src/main/java/org/terasology/changingBlocks/conditional/BlockCondition.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/BlockCondition.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2019 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks.conditional;
 
 import org.terasology.engine.math.Side;

--- a/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/ConditionalBlocksSystem.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks.conditional;
 
@@ -81,11 +81,12 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
         triggerCollections.compute(
             trigger.toLowerCase(),
             (k, v) -> {
-                if (v == null) {
-                    v = new ArrayList<>();
+                List<EntityRef> vCopy = v;
+                if (vCopy == null) {
+                    vCopy = new ArrayList<>();
                 }
-                v.add(triggerable);
-                return v;
+                vCopy.add(triggerable);
+                return vCopy;
             }
         );
     }
@@ -108,7 +109,9 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
                         if (distance >= change.minDistance && distance <= change.maxDistance) {
                             Vector3f direction = triggerPosition.sub(changeSpot, new Vector3f());
                             //if the change can occur when obstructed, or otherwise if there is no obstruction
-                            if (change.throughWalls || physics.rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD).getEntity() == entity) {
+                            if (change.throughWalls || physics
+                                    .rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD)
+                                    .getEntity() == entity) {
                                 //if the random odds are in our favor
                                 if (change.chance >= random.nextFloat()) {
                                     worldprovider.setBlock(new Vector3i(changeSpot, RoundingMode.FLOOR), blockManager.getBlock(change.targetBlockID));
@@ -140,10 +143,13 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
                             //if the angle is within the change's field of view limit
                             if (direction.angle(new Vector3f(global.direction())) <= change.fieldOfView) {
                                 //if the change can occur when obstructed, or otherwise if there is no obstruction
-                                if (change.throughWalls || physics.rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD).getEntity() == entity) {
+                                if (change.throughWalls || physics
+                                        .rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD)
+                                        .getEntity() == entity) {
                                     //if the random odds are in our favor
                                     if (change.chance >= random.nextFloat()) {
-                                        worldprovider.setBlock(new Vector3i(changeSpot, RoundingMode.FLOOR), blockManager.getBlock(change.targetBlockID));
+                                        worldprovider.setBlock(new Vector3i(changeSpot, RoundingMode.FLOOR),
+                                                blockManager.getBlock(change.targetBlockID));
                                     }
                                 }
                             }
@@ -168,10 +174,13 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
                     if (distance >= change.minDistance && distance <= change.maxDistance) {
                         Vector3f direction = triggerPosition.sub(changeSpot, new Vector3f());
                         //if the change can occur when obstructed, or otherwise if there is no obstruction
-                        if (change.throughWalls || physics.rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD).getEntity() == entity) {
+                        if (change.throughWalls || physics
+                                .rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD)
+                                .getEntity() == entity) {
                             //if the random odds are in our favor
                             if (change.chance >= random.nextFloat()) {
-                                worldprovider.setBlock(new Vector3i(changeSpot, RoundingMode.FLOOR), blockManager.getBlock(change.targetBlockID));
+                                worldprovider.setBlock(new Vector3i(changeSpot, RoundingMode.FLOOR),
+                                        blockManager.getBlock(change.targetBlockID));
                             }
                         }
                     }
@@ -199,10 +208,13 @@ public class ConditionalBlocksSystem extends BaseComponentSystem {
                             //if the angle is within the change's field of view limit
                             if (direction.angle(new Vector3f(global.direction())) <= change.fieldOfView) {
                                 //if the change can occur when obstructed, or otherwise if there is no obstruction
-                                if (change.throughWalls || physics.rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD).getEntity() == entity) {
+                                if (change.throughWalls || physics
+                                        .rayTrace(changeSpot, direction, change.maxDistance, StandardCollisionGroup.WORLD)
+                                        .getEntity() == entity) {
                                     //if the random odds are in our favor
                                     if (change.chance >= random.nextFloat()) {
-                                        worldprovider.setBlock(new Vector3i(changeSpot, RoundingMode.FLOOR), blockManager.getBlock(change.targetBlockID));
+                                        worldprovider.setBlock(new Vector3i(changeSpot, RoundingMode.FLOOR),
+                                                blockManager.getBlock(change.targetBlockID));
                                     }
                                 }
                             }

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockBlockDirectedComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockBlockDirectedComponent.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks.conditional.components;
 

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockBlockNearbyComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockBlockNearbyComponent.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks.conditional.components;
 

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockEntityDirectedComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockEntityDirectedComponent.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks.conditional.components;
 

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockEntityNearbyComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ChangeBlockEntityNearbyComponent.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks.conditional.components;
 

--- a/src/main/java/org/terasology/changingBlocks/conditional/components/ConditionalBlockChangeComponent.java
+++ b/src/main/java/org/terasology/changingBlocks/conditional/components/ConditionalBlockChangeComponent.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.changingBlocks.conditional.components;
 


### PR DESCRIPTION
Fixes #14 
Depends on https://github.com/MovingBlocks/Terasology/pull/5061

### Contains

- before this PR, a prefab specifying the `ChangingBlocks` component had to make sure that the keys in the `blockFamilyStages` map match the string representation of the respective `BlockUri`s including case
  example for a mismatch: `PlantPack:Corn1` (as referenced in `PlantPack:Corn.prefab`) != `PlantPack:corn1` (in-game `BlockUri` of `PlantPack:Corn1.block`)
- by sanitizing the reference in the `ChangingBlocks` component via the `BlockUriTypeHandler` and comparing it with the in-game `BlockUri`, the logic becomes case insensitive

### How to test

Requires https://github.com/MovingBlocks/Terasology/pull/5062

1. Start Terasology
2. Select `CoreGameplay` and add the `PlantPack` and `ChangingBlocks` modules in the Advanced Game Setup (AGS)
3. Open the in-game console (F1) and execute `give corn1`
4. Select the new item in your inventory quickslot bar and right-click to place it on a dirt/grass block
5. Observe the block being placed successfully

### Outstanding before merge

- [x] identify `ChangingBlocks` usages other than `PlantPack` and create follow-up issues to adjust map formatting
   - no further omega usages of `ChangingBlocks` component